### PR TITLE
Setup development environment

### DIFF
--- a/mbti-app/.gitignore
+++ b/mbti-app/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+server.log


### PR DESCRIPTION
This PR sets up the development environment:

- Add server.log to gitignore
- Configure development server to run on port 51454
- Allow external access (0.0.0.0)